### PR TITLE
Docs: Correct default port from 8751 to 8501

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ streamlit run src/notebookllama/Home.py
 >
 > _You might need to install `ffmpeg` if you do not have it installed already_
 
-And start exploring the app at `http://localhost:8751/`.
+And start exploring the app at `http://localhost:8501/`.
 
 ### Contributing
 


### PR DESCRIPTION
Hi! I noticed the documentation specifies that the app runs on port `8751`. However, Streamlit's default port is `8501`, and a search of the repository shows no configuration files that override this.

This PR updates the documentation to reflect the correct default port to avoid confusion for new users.