### PR TITLE
fix: Windows-specific issues related to across-threads IO operations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "notebookllama"
-version = "0.2.3"
+version = "0.3.0"
 description = "An OSS and LlamaCloud-backed alternative to NotebookLM"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/notebookllama/Home.py
+++ b/src/notebookllama/Home.py
@@ -4,6 +4,7 @@ import os
 import asyncio
 import tempfile as temp
 from dotenv import load_dotenv
+import sys
 import time
 import streamlit.components.v1 as components
 
@@ -20,7 +21,7 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
 load_dotenv()
 
 # define a custom span exporter
-span_exporter = OTLPSpanExporter("http://0.0.0.0:4318/v1/traces")
+span_exporter = OTLPSpanExporter("http://localhost:4318/v1/traces")
 
 # initialize the instrumentation object
 instrumentor = LlamaIndexOpenTelemetry(
@@ -42,31 +43,63 @@ def read_html_file(file_path: str) -> str:
     with open(file_path, "r", encoding="utf-8") as f:
         return f.read()
 
-
 async def run_workflow(file: io.BytesIO) -> Tuple[str, str, str, str, str]:
-    fl = temp.NamedTemporaryFile(suffix=".pdf", delete=False, delete_on_close=False)
-    content = file.getvalue()
-    with open(fl.name, "wb") as f:
-        f.write(content)
-    st_time = int(time.time() * 1000000)
-    ev = FileInputEvent(file=fl.name)
-    result: NotebookOutputEvent = await WF.run(start_event=ev)
-    q_and_a = ""
-    for q, a in zip(result.questions, result.answers):
-        q_and_a += f"**{q}**\n\n{a}\n\n"
-    bullet_points = "## Bullet Points\n\n- " + "\n- ".join(result.highlights)
-    os.remove(fl.name)
-    mind_map = result.mind_map
-    if Path(mind_map).is_file():
-        mind_map = read_html_file(mind_map)
-        os.remove(result.mind_map)
-    end_time = int(time.time() * 1000000)
-    sql_engine.to_sql_database(start_time=st_time, end_time=end_time)
-    return result.md_content, result.summary, q_and_a, bullet_points, mind_map
-
+    # Create temp file with proper Windows handling
+    with temp.NamedTemporaryFile(suffix=".pdf", delete=False) as fl:
+        content = file.getvalue()
+        fl.write(content)
+        fl.flush()  # Ensure data is written
+        temp_path = fl.name
+    
+    try:
+        st_time = int(time.time() * 1000000)
+        ev = FileInputEvent(file=temp_path)
+        result: NotebookOutputEvent = await WF.run(start_event=ev)
+        
+        q_and_a = ""
+        for q, a in zip(result.questions, result.answers):
+            q_and_a += f"**{q}**\n\n{a}\n\n"
+        bullet_points = "## Bullet Points\n\n- " + "\n- ".join(result.highlights)
+        
+        mind_map = result.mind_map
+        if Path(mind_map).is_file():
+            mind_map = read_html_file(mind_map)
+            try:
+                os.remove(result.mind_map)
+            except OSError:
+                pass  # File might be locked on Windows
+        
+        end_time = int(time.time() * 1000000)
+        sql_engine.to_sql_database(start_time=st_time, end_time=end_time)
+        return result.md_content, result.summary, q_and_a, bullet_points, mind_map
+    
+    finally:
+        try:
+            os.remove(temp_path)
+        except OSError:
+            await asyncio.sleep(0.1)
+            try:
+                os.remove(temp_path)
+            except OSError:
+                pass  # Give up if still locked
 
 def sync_run_workflow(file: io.BytesIO):
-    return asyncio.run(run_workflow(file=file))
+    try:
+        # Try to use existing event loop
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            # If loop is already running, schedule the coroutine
+            import concurrent.futures
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                future = executor.submit(asyncio.run, run_workflow(file))
+                return future.result()
+        else:
+            return loop.run_until_complete(run_workflow(file))
+    except RuntimeError:
+        # No event loop exists, create one
+        if sys.platform == 'win32':
+            asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+        return asyncio.run(run_workflow(file))
 
 
 async def create_podcast(file_content: str):

--- a/src/notebookllama/instrumentation.py
+++ b/src/notebookllama/instrumentation.py
@@ -47,7 +47,7 @@ class OtelTracesSqlEngine:
 
     def _to_pandas(self, data: Dict[str, Any]) -> pd.DataFrame:
         rows: List[Dict[str, Any]] = []
-        
+
         # Loop over each trace
         for trace in data.get("data", []):
             trace_id = trace.get("traceID")
@@ -55,7 +55,7 @@ class OtelTracesSqlEngine:
                 pid: proc.get("serviceName")
                 for pid, proc in trace.get("processes", {}).items()
             }
-            
+
             for span in trace.get("spans", []):
                 span_id = span.get("spanID")
                 operation = span.get("operationName")
@@ -74,7 +74,7 @@ class OtelTracesSqlEngine:
                 parent_span_id = None
                 if span.get("references"):
                     parent_span_id = span["references"][0].get("spanID")
-                    
+
                 rows.append(
                     {
                         "trace_id": trace_id,
@@ -87,7 +87,7 @@ class OtelTracesSqlEngine:
                         "service_name": service,
                     }
                 )
-        
+
         return pd.DataFrame(rows)
 
     def _to_sql(

--- a/src/notebookllama/instrumentation.py
+++ b/src/notebookllama/instrumentation.py
@@ -1,9 +1,6 @@
 import requests
 import time
-import csv
 import pandas as pd
-import tempfile as temp
-import os
 
 from sqlalchemy import Engine, create_engine, Connection, Result
 from typing import Optional, Dict, Any, List, Literal, Union, cast
@@ -50,6 +47,7 @@ class OtelTracesSqlEngine:
 
     def _to_pandas(self, data: Dict[str, Any]) -> pd.DataFrame:
         rows: List[Dict[str, Any]] = []
+        
         # Loop over each trace
         for trace in data.get("data", []):
             trace_id = trace.get("traceID")
@@ -57,7 +55,7 @@ class OtelTracesSqlEngine:
                 pid: proc.get("serviceName")
                 for pid, proc in trace.get("processes", {}).items()
             }
-
+            
             for span in trace.get("spans", []):
                 span_id = span.get("spanID")
                 operation = span.get("operationName")
@@ -76,7 +74,7 @@ class OtelTracesSqlEngine:
                 parent_span_id = None
                 if span.get("references"):
                     parent_span_id = span["references"][0].get("spanID")
-
+                    
                 rows.append(
                     {
                         "trace_id": trace_id,
@@ -89,29 +87,8 @@ class OtelTracesSqlEngine:
                         "service_name": service,
                     }
                 )
-
-        # Define the CSV header
-        fieldnames = [
-            "trace_id",
-            "span_id",
-            "parent_span_id",
-            "operation_name",
-            "start_time",
-            "duration",
-            "status_code",
-            "service_name",
-        ]
-
-        fl = temp.NamedTemporaryFile(suffix=".csv", delete=False, delete_on_close=False)
-        # Write to CSV
-        with open(fl.name, "w", newline="") as csvfile:
-            writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
-            writer.writeheader()
-            writer.writerows(rows)
-
-        df = pd.read_csv(fl)
-        os.remove(fl.name)
-        return df
+        
+        return pd.DataFrame(rows)
 
     def _to_sql(
         self,

--- a/src/notebookllama/utils.py
+++ b/src/notebookllama/utils.py
@@ -24,6 +24,7 @@ from pyvis.network import Network
 
 load_dotenv()
 
+
 class MarkdownTextAnalyzer(MarkdownAnalyzer):
     @override
     def __init__(self, text: str):
@@ -32,9 +33,11 @@ class MarkdownTextAnalyzer(MarkdownAnalyzer):
         self.tokens = parser.parse()
         self.references = parser.references
         self.footnotes = parser.footnotes
-        self.inline_parser = InlineParser(references=self.references, footnotes=self.footnotes)
+        self.inline_parser = InlineParser(
+            references=self.references, footnotes=self.footnotes
+        )
         self._parse_inline_tokens()
-        
+
 
 class Node(BaseModel):
     id: str

--- a/uv.lock
+++ b/uv.lock
@@ -1744,7 +1744,7 @@ wheels = [
 
 [[package]]
 name = "notebookllama"
-version = "0.2.3"
+version = "0.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "audioop-lts" },


### PR DESCRIPTION
Introduces several patches for Windows:

- Using `localhost` instead of `0.0.0.0`because Windows likes it more
- Introducing thread-safe async policies for windows
- `_to_pandas` in `OtelSqlEngine` now converts `rows` directly without converting them to a temporary CSV file
- Introducing `MarkdownTextAnalyzer` to avoid using an intermediate temporary file to use as an input to `MarkdownAnalyzer`
 