### PR TITLE
Fix: Increase MCP Client Timeout to Prevent Processing Errors

### DIFF
--- a/src/notebookllama/workflow.py
+++ b/src/notebookllama/workflow.py
@@ -6,7 +6,7 @@ from workflows.resource import Resource
 from llama_index.tools.mcp import BasicMCPClient
 from typing import Annotated, List, Union
 
-MCP_CLIENT = BasicMCPClient(command_or_url="http://localhost:8000/mcp")
+MCP_CLIENT = BasicMCPClient(command_or_url="http://localhost:8000/mcp", timeout=120)
 
 
 class FileInputEvent(StartEvent):


### PR DESCRIPTION
### Description

This PR addresses the recurring timeout error where processing larger documents fails after 30 seconds. The error `mcp.shared.exceptions.McpError: Timed out while waiting for response to ClientRequest` occurs during the `extract_file_data` step because the server-side processing takes longer than the client's default timeout.

---

**Before:**

<img width="733" height="703" alt="Screenshot 2025-07-12 at 11 19 51 AM" src="https://github.com/user-attachments/assets/5d8661b5-8bdd-4fe7-b311-66aec261136a" />

**After:**

<img width="749" height="493" alt="Screenshot 2025-07-12 at 11 22 05 AM" src="https://github.com/user-attachments/assets/f71937d5-8e27-4d93-b40f-35c60d9d2e29" />

---

### The Fix

This is a quick-fix that increases the timeout for the `BasicMCPClient` from 30 seconds to 120 seconds. This provides a more generous and stable window for the server to complete its work, preventing the premature timeout and improving the user experience.

### Future Work

While this hot fix immediately resolves the issue for users, a more robust long-term solution can still be explored. Potential improvements include:

* Implementing an asynchronous polling mechanism where the client submits a processing job and checks for the result periodically.
* Optimizing the backend `extract_file_data` workflow to reduce processing time.

I'll start working on this, but in the meantime, this hot-fix should resolve our current issues.

### Related Issues

* Closes #26 #23 
* Addresses #16 