### PR TITLE
feat: Add support for Ollama

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 OPENAI_API_KEY="sk-***"
+OLLAMA_BASE_URL="http://localhost:11434"
 LLAMACLOUD_API_KEY="llx-***"
 ELEVENLABS_API_KEY="sk_***"
 pgql_db="postgres"

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,4 @@
 OPENAI_API_KEY="sk-***"
-OLLAMA_BASE_URL="http://localhost:11434"
 LLAMACLOUD_API_KEY="llx-***"
 ELEVENLABS_API_KEY="sk_***"
 pgql_db="postgres"

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 OPENAI_API_KEY="sk-***"
+# OPENAI_API_MODEL="" # Uncomment to change the default OPENAI_API model ("gpt-4.1") and specify a new one
+# OLLAMA_BASE_URL="http://localhost:11434" # Comment OPENAI_API_KEY and uncomment OLLAMA_BASE_URL to use Ollama
+# OLLAMA_MODEL="" # Uncomment to change the default OLLAMA model ("llama2") and specify a new one
 LLAMACLOUD_API_KEY="llx-***"
 ELEVENLABS_API_KEY="sk_***"
 pgql_db="postgres"

--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ Next, open the `.env` file and add your API keys:
 - `ELEVENLABS_API_KEY`: find it [on ElevenLabs Settings](https://elevenlabs.io/app/settings/api-keys)
 - `LLAMACLOUD_API_KEY`: find it [on LlamaCloud Dashboard](https://cloud.llamaindex.ai?utm_source=demo&utm_medium=notebookLM)
 
+To use Ollama instead of the OpenAI API, add your base URL:
+
+- `OLLAMA_BASE_URL`: by default is "http://localhost:11434"
+
+Optionally, you can also add the model:
+
+- `OPENAI_API_MODEL`: by default is "gpt-4.1"
+- `OLLAMA_MODEL`: by default is "llama2"
+
 **4. Activate the Virtual Environment**
 
 (on mac/unix)

--- a/src/notebookllama/querying.py
+++ b/src/notebookllama/querying.py
@@ -1,30 +1,50 @@
 from dotenv import load_dotenv
+import logging
 import os
 
 from llama_index.core.query_engine import CitationQueryEngine
 from llama_index.core.base.response.schema import Response
 from llama_index.indices.managed.llama_cloud import LlamaCloudIndex
 from llama_index.llms.openai import OpenAIResponses
+from llama_index.llms.ollama import Ollama
 from typing import Union, cast
 
+logger = logging.getLogger(__name__)
 load_dotenv()
+
+LLM = None
+RETR = None
+QE = None
 
 if (
     os.getenv("LLAMACLOUD_API_KEY", None)
     and os.getenv("LLAMACLOUD_PIPELINE_ID", None)
-    and os.getenv("OPENAI_API_KEY", None)
 ):
-    LLM = OpenAIResponses(model="gpt-4.1", api_key=os.getenv("OPENAI_API_KEY"))
-    PIPELINE_ID = os.getenv("LLAMACLOUD_PIPELINE_ID")
     RETR = LlamaCloudIndex(
-        api_key=os.getenv("LLAMACLOUD_API_KEY"), pipeline_id=PIPELINE_ID
+        api_key=os.getenv("LLAMACLOUD_API_KEY"),
+        pipeline_id=os.getenv("LLAMACLOUD_PIPELINE_ID", None)
     ).as_retriever()
+
+if os.getenv("OPENAI_API_KEY", None):
+    LLM = OpenAIResponses(
+        model=os.getenv("OPENAI_API_MODEL", "gpt-4.1"),
+        api_key=os.getenv("OPENAI_API_KEY")
+    )
+elif os.getenv("OLLAMA_BASE_URL", None):
+    LLM = Ollama(
+        model=os.getenv("OLLAMA_MODEL", "llama2"),
+        base_url=os.getenv("OLLAMA_BASE_URL")
+    )
+
+if RETR and LLM:
     QE = CitationQueryEngine(
         retriever=RETR,
         llm=LLM,
         citation_chunk_size=256,
         citation_chunk_overlap=50,
     )
+else:
+    logger.warning("Missing LLM or retriever - Query Engine not initialized")
 
 
 async def query_index(question: str) -> Union[str, None]:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,7 +22,10 @@ skip_condition = not (
     os.getenv("LLAMACLOUD_API_KEY", None)
     and os.getenv("EXTRACT_AGENT_ID", None)
     and os.getenv("LLAMACLOUD_PIPELINE_ID", None)
-    and os.getenv("OPENAI_API_KEY", None)
+    and (
+        os.getenv("OPENAI_API_KEY", None)
+        or os.getenv("OLLAMA_BASE_URL", None)
+    )
 )
 
 


### PR DESCRIPTION
This PR adds support for **Ollama** integration, allowing users to connect NotebookLlama with Ollama's model-serving framework while maintaining full backward compatibility.

## Changes
- **New**: Ollama configuration via `OLLAMA_BASE_URL` env variable
- **New**: Optional LLM specification via `OPENAI_API_MODEL` and `OLLAMA_MODEL` env variables
- **Added**: Logger warnings when components like the PodcastGenerator or other variables are not initialized
- **Updated**: All LLM client instantiation to optionally use Ollama
- **Updated**: Documentation in `README.md` and `.env.example` to include Ollama setup instructions

## Configuration
- **Default**: NotebookLlama works exactly as before
- **Ollama**: Set `OLLAMA_BASE_URL` in your `.env` file to use Ollama models.
- **LLM**: Set `OPENAI_API_MODEL` or `OLLAMA_MODEL` in your `.env` file to change the default LLM

## Backward Compatibility
- **100% backward compatible** — existing code and setups require no changes
- **Optional feature** - you can opt into Ollama LLMs and change the default OpenAI "gpt-4.1" model.

This addresses the Ollama integration feature discussed in #10 